### PR TITLE
Add `Module::getOrInsertGlobal(string, llvm::Type)`

### DIFF
--- a/include/IR/Module.h
+++ b/include/IR/Module.h
@@ -48,6 +48,8 @@ private:
 
     Napi::Value getGlobalVariable(const Napi::CallbackInfo &info);
 
+    Napi::Value getOrInsertGlobal(const Napi::CallbackInfo &info);
+
     void addModuleFlag(const Napi::CallbackInfo &info);
 
     Napi::Value empty(const Napi::CallbackInfo &info);

--- a/include/Util/ErrMsg.h
+++ b/include/Util/ErrMsg.h
@@ -24,6 +24,7 @@ namespace ErrMsg {
             constexpr const char *getFunction = "Module.getFunction needs to be called with: (name: string)";
             constexpr const char *getOrInsertFunction = "Module.getOrInsertFunction needs to be called with: (name: string, fnType: FunctionType)";
             constexpr const char *getGlobalVariable = "Module.getGlobalVariable needs to be called with: (name: string, allowInternal?: boolean)";
+            constexpr const char *getOrInsertGlobal = "Module.getOrInsertGlobal needs to be called with: (name: string, type: Type)";
             constexpr const char *addModuleFlag = "Module.addModuleFlag needs to be called with (behavior: number, key: string, value: number)"
                                                   "\n\t - limit: behavior should belong to [1, 7]";
         }

--- a/llvm-bindings.d.ts
+++ b/llvm-bindings.d.ts
@@ -227,6 +227,8 @@ declare namespace llvm {
 
         public getGlobalVariable(name: string, allowInternal?: boolean): GlobalVariable | null;
 
+        public getOrInsertGlobal(name: string, varType: Type): FunctionCallee;
+
         public addModuleFlag(behavior: number, key: string, value: number): void;
 
         public empty(): boolean;

--- a/src/IR/Module.cpp
+++ b/src/IR/Module.cpp
@@ -31,6 +31,7 @@ void Module::Init(Napi::Env env, Napi::Object &exports) {
             InstanceMethod("getFunction", &Module::getFunction),
             InstanceMethod("getOrInsertFunction", &Module::getOrInsertFunction),
             InstanceMethod("getGlobalVariable", &Module::getGlobalVariable),
+            InstanceMethod("getOrInsertGlobal", &Module::getOrInsertGlobal),
             InstanceMethod("addModuleFlag", &Module::addModuleFlag),
             InstanceMethod("empty", &Module::empty),
             InstanceMethod("print", &Module::print)
@@ -196,6 +197,17 @@ Napi::Value Module::getGlobalVariable(const Napi::CallbackInfo &info) {
         return env.Null();
     }
     throw Napi::TypeError::New(env, ErrMsg::Class::Module::getGlobalVariable);
+}
+
+Napi::Value Module::getOrInsertGlobal(const Napi::CallbackInfo &info) {
+    Napi::Env env = info.Env();
+    if (info.Length() == 2 && info[0].IsString() && Type::IsClassOf(info[1])) {
+        std::string functionName = info[0].As<Napi::String>();
+        llvm::Type *type = Type::Extract(info[1]);
+        llvm::Constant* glob = module->getOrInsertGlobal(functionName, type);
+        return GlobalVariable::New(env, dyn_cast_or_null<llvm::GlobalVariable>(glob));
+    }
+    throw Napi::TypeError::New(env, ErrMsg::Class::Module::getOrInsertGlobal);
 }
 
 void Module::addModuleFlag(const Napi::CallbackInfo &info) {

--- a/src/IR/Module.cpp
+++ b/src/IR/Module.cpp
@@ -205,7 +205,7 @@ Napi::Value Module::getOrInsertGlobal(const Napi::CallbackInfo &info) {
         std::string functionName = info[0].As<Napi::String>();
         llvm::Type *type = Type::Extract(info[1]);
         llvm::Constant* glob = module->getOrInsertGlobal(functionName, type);
-        return GlobalVariable::New(env, dyn_cast_or_null<llvm::GlobalVariable>(glob));
+        return GlobalVariable::New(env, llvm::cast<llvm::GlobalVariable>(glob));
     }
     throw Napi::TypeError::New(env, ErrMsg::Class::Module::getOrInsertGlobal);
 }

--- a/tests/IR/Module.spec.ts
+++ b/tests/IR/Module.spec.ts
@@ -359,4 +359,13 @@ describe('Test Module', () => {
             expect(module.print()).toMatchSnapshot();
         });
     });
+
+    describe('Global variables', () => {
+        test('Global variable declared', () => {
+            const context = new llvm.LLVMContext();
+            const module = new llvm.Module(FileName, context);
+            module.getOrInsertGlobal('HomerSimpson', llvm.Type.getInt32Ty(context));
+            expect(module.print()).toContain('@HomerSimpson');
+        });
+    });
 });


### PR DESCRIPTION
We want to link also external global variables between .o files.
So we need this method to add declarations instead of definitions.